### PR TITLE
[ts-utils] Result Type - Change Ok Operations

### DIFF
--- a/packages/ts-utils/__test__/index.test.ts
+++ b/packages/ts-utils/__test__/index.test.ts
@@ -17,13 +17,13 @@ describe('All utils are exported', () => {
     expect(utils.result).toHaveProperty('error');
     expect(utils.result).toHaveProperty('isOk');
     expect(utils.result).toHaveProperty('isError');
-    expect(utils.result).toHaveProperty('map');
+    expect(utils.result).toHaveProperty('mapOk');
     expect(utils.result).toHaveProperty('mapError');
-    expect(utils.result).toHaveProperty('flatMap');
+    expect(utils.result).toHaveProperty('flatMapOk');
     expect(utils.result).toHaveProperty('flatMapError');
-    expect(utils.result).toHaveProperty('get');
+    expect(utils.result).toHaveProperty('getOk');
     expect(utils.result).toHaveProperty('getError');
-    expect(utils.result).toHaveProperty('getOrElse');
+    expect(utils.result).toHaveProperty('getOkOrElse');
     expect(utils.result).toHaveProperty('getErrorOrElse');
   });
 });

--- a/packages/ts-utils/__test__/result.test.ts
+++ b/packages/ts-utils/__test__/result.test.ts
@@ -3,13 +3,13 @@ import {
   error,
   isOk,
   isError,
-  get,
-  getOrElse,
+  getOk,
+  getOkOrElse,
   getError,
   getErrorOrElse,
-  map,
+  mapOk,
   mapError,
-  flatMap,
+  flatMapOk,
   flatMapError,
 } from '../src/result';
 import {some, none} from '../src/option';
@@ -62,15 +62,15 @@ describe('isError works correctly', () => {
   });
 });
 
-describe('get works correctly', () => {
-  test('get returns some value on ok', () => {
-    expect(get(ok('string'))).toEqual(some('string'));
-    expect(get(ok(1))).toEqual(some(1));
+describe('getOk works correctly', () => {
+  test('getOk returns some value on ok', () => {
+    expect(getOk(ok('string'))).toEqual(some('string'));
+    expect(getOk(ok(1))).toEqual(some(1));
   });
 
-  test('get returns none on error', () => {
-    expect(get(error('string'))).toEqual(none());
-    expect(get(error(1))).toEqual(none());
+  test('getOk returns none on error', () => {
+    expect(getOk(error('string'))).toEqual(none());
+    expect(getOk(error(1))).toEqual(none());
   });
 });
 
@@ -86,15 +86,15 @@ describe('getError works correctly', () => {
   });
 });
 
-describe('getOrElse works correctly', () => {
-  test('getOrElse returns the value on ok', () => {
-    expect(getOrElse('default')(ok('string'))).toEqual('string');
-    expect(getOrElse(0)(ok(1))).toEqual(1);
+describe('getOkOrElse works correctly', () => {
+  test('getOkOrElse returns the value on ok', () => {
+    expect(getOkOrElse('default')(ok('string'))).toEqual('string');
+    expect(getOkOrElse(0)(ok(1))).toEqual(1);
   });
 
-  test('getOrElse returns the default value on error', () => {
-    expect(getOrElse('default')(error('string'))).toEqual('default');
-    expect(getOrElse(0)(error(1))).toEqual(0);
+  test('getOkOrElse returns the default value on error', () => {
+    expect(getOkOrElse('default')(error('string'))).toEqual('default');
+    expect(getOkOrElse(0)(error(1))).toEqual(0);
   });
 });
 
@@ -110,23 +110,23 @@ describe('getErrorOrElse works correctly', () => {
   });
 });
 
-describe('map works correctly', () => {
-  test('map successfully maps the ok value', () => {
-    expect(map((s: string) => 'hello ' + s)(ok('string'))).toEqual({
+describe('mapOk works correctly', () => {
+  test('mapOk successfully mapOk the ok value', () => {
+    expect(mapOk((s: string) => 'hello ' + s)(ok('string'))).toEqual({
       _tag: 'Ok',
       value: 'hello string',
     });
-    expect(map((x: number) => x * 2)(ok(1))).toEqual({
+    expect(mapOk((x: number) => x * 2)(ok(1))).toEqual({
       _tag: 'Ok',
       value: 1 * 2,
     });
   });
-  test('map skips the operation on error', () => {
-    expect(map((s: string) => 'hello ' + s)(error('string'))).toEqual({
+  test('mapOk skips the operation on error', () => {
+    expect(mapOk((s: string) => 'hello ' + s)(error('string'))).toEqual({
       _tag: 'Error',
       value: 'string',
     });
-    expect(map((x: number) => x * 2)(error(1))).toEqual({
+    expect(mapOk((x: number) => x * 2)(error(1))).toEqual({
       _tag: 'Error',
       value: 1,
     });
@@ -156,23 +156,25 @@ describe('mapError works correctly', () => {
   });
 });
 
-describe('flatMap works correctly', () => {
-  test('flatMap successfully maps the ok value', () => {
-    expect(flatMap((s: string) => ok('hello ' + s))(ok('string'))).toEqual({
+describe('flatMapOk works correctly', () => {
+  test('flatMapOk successfully maps the ok value', () => {
+    expect(flatMapOk((s: string) => ok('hello ' + s))(ok('string'))).toEqual({
       _tag: 'Ok',
       value: 'hello string',
     });
-    expect(flatMap((x: number) => ok(x * 2))(ok(1))).toEqual({
+    expect(flatMapOk((x: number) => ok(x * 2))(ok(1))).toEqual({
       _tag: 'Ok',
       value: 1 * 2,
     });
   });
-  test('flatMap skips the operation on error', () => {
-    expect(flatMap((s: string) => ok('hello ' + s))(error('string'))).toEqual({
-      _tag: 'Error',
-      value: 'string',
-    });
-    expect(flatMap((x: number) => ok(x * 2))(error(1))).toEqual({
+  test('flatMapOk skips the operation on error', () => {
+    expect(flatMapOk((s: string) => ok('hello ' + s))(error('string'))).toEqual(
+      {
+        _tag: 'Error',
+        value: 'string',
+      },
+    );
+    expect(flatMapOk((x: number) => ok(x * 2))(error(1))).toEqual({
       _tag: 'Error',
       value: 1,
     });

--- a/packages/ts-utils/src/result.ts
+++ b/packages/ts-utils/src/result.ts
@@ -28,7 +28,7 @@ export function isError<T, U>(result: Result<T, U>): boolean {
   return result._tag === 'Error';
 }
 
-export function get<T, U>(result: Result<T, U>): Option<T> {
+export function getOk<T, U>(result: Result<T, U>): Option<T> {
   if (result._tag === 'Ok') {
     return option.some(result.value);
   } else {
@@ -44,7 +44,7 @@ export function getError<T, U>(result: Result<T, U>): Option<U> {
   }
 }
 
-export function getOrElse<T, U>(value: T): (result: Result<T, U>) => T {
+export function getOkOrElse<T, U>(value: T): (result: Result<T, U>) => T {
   return (result: Result<T, U>): T => {
     if (result._tag === 'Ok') {
       return result.value;
@@ -64,7 +64,7 @@ export function getErrorOrElse<T, U>(value: U): (result: Result<T, U>) => U {
   };
 }
 
-export function map<T, U, T1>(
+export function mapOk<T, U, T1>(
   fn: (value: T) => T1,
 ): (result: Result<T, U>) => Result<T1, U> {
   return (result) => {
@@ -88,7 +88,7 @@ export function mapError<T, U, U1>(
   };
 }
 
-export function flatMap<T, U, T1>(
+export function flatMapOk<T, U, T1>(
   fn: (value: T) => Result<T1, U>,
 ): (result: Result<T, U>) => Result<T1, U> {
   return (result: Result<T, U>) => {
@@ -117,12 +117,12 @@ export default {
   error,
   isOk,
   isError,
-  get,
+  getOk,
   getError,
-  getOrElse,
+  getOkOrElse,
   getErrorOrElse,
-  map,
+  mapOk,
   mapError,
-  flatMap,
+  flatMapOk,
   flatMapError,
 };


### PR DESCRIPTION
Change Result's Ok Operation to use `mapOk`, `getOk`, `flatMapOk`, `getOkOrElse`.