### PR TITLE
[ts-utils] ADT - integrate ts-adt

### DIFF
--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -7,7 +7,7 @@ const {match, matchI, matchPI} = adt;
 describe('match works correctly', () => {
   test('match works correctly for option', () => {
     const someString = some('str');
-    const someStringRes: string = match({
+    const someStringRes = match({
       Some: ({value}) => value,
       None: () => 'nothing',
     })(someString);

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -2,7 +2,7 @@ import {result, option, adt, Option, Result} from '../src';
 
 const {some, none} = option;
 const {ok, error} = result;
-const {match, matchLast, matchP} = adt;
+const {match, matchLast, matchP, matchPLast} = adt;
 
 describe('match works correctly', () => {
   test('match works correctly for option', () => {
@@ -114,6 +114,50 @@ describe('matchP works correctly', () => {
       },
       (_result) => 'ok string',
     );
+
+    expect(okStringRes).toEqual('ok string');
+    expect(errorStringRes).toEqual('error string');
+  });
+});
+
+describe('matchPLast works correctly', () => {
+  test('matchPLast works correctly for option', () => {
+    const someString = some('str');
+    const someStringRes = matchPLast(
+      {
+        Some: ({value}) => value,
+      },
+      (_option) => 'nothing',
+    )(someString);
+
+    const noString: Option<string> = none();
+    const noStringRes = matchPLast(
+      {
+        Some: ({value}) => value,
+      },
+      (_option) => 'nothing',
+    )(noString);
+
+    expect(someStringRes).toEqual('str');
+    expect(noStringRes).toEqual('nothing');
+  });
+
+  test('matchPLast works correctly for result', () => {
+    const okString: Result<string, string> = ok('ok string');
+    const okStringRes = matchPLast(
+      {
+        Error: ({value}) => value,
+      },
+      (_result) => 'ok string',
+    )(okString);
+
+    const errorString: Result<string, string> = error('error string');
+    const errorStringRes = matchPLast(
+      {
+        Error: ({value}) => value,
+      },
+      (_result) => 'ok string',
+    )(errorString);
 
     expect(okStringRes).toEqual('ok string');
     expect(errorStringRes).toEqual('error string');

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -4,42 +4,6 @@ const {some, none} = option;
 const {ok, error} = result;
 const {match, matchLast, matchP} = adt;
 
-describe('matchLast works correctly', () => {
-  test('matchLast works correctly for option', () => {
-    const someString = some('str');
-    const someStringRes = matchLast({
-      Some: ({value}) => value,
-      None: () => 'nothing',
-    })(someString);
-
-    const noString: Option<string> = none();
-    const noStringRes = matchLast({
-      Some: ({value}) => value,
-      None: () => 'nothing',
-    })(noString);
-
-    expect(someStringRes).toEqual('str');
-    expect(noStringRes).toEqual('nothing');
-  });
-
-  test('matchLast works correctly for result', () => {
-    const okString: Result<string, string> = ok('ok string');
-    const okStringRes = matchLast({
-      Ok: ({value}) => value,
-      Error: ({value}) => value,
-    })(okString);
-
-    const errorString: Result<string, string> = error('error string');
-    const errorStringRes = matchLast({
-      Ok: ({value}) => value,
-      Error: ({value}) => value,
-    })(errorString);
-
-    expect(okStringRes).toEqual('ok string');
-    expect(errorStringRes).toEqual('error string');
-  });
-});
-
 describe('match works correctly', () => {
   test('match works correctly for option', () => {
     const someString = some('str');
@@ -70,6 +34,42 @@ describe('match works correctly', () => {
       Ok: ({value}) => value,
       Error: ({value}) => value,
     });
+
+    expect(okStringRes).toEqual('ok string');
+    expect(errorStringRes).toEqual('error string');
+  });
+});
+
+describe('matchLast works correctly', () => {
+  test('matchLast works correctly for option', () => {
+    const someString = some('str');
+    const someStringRes = matchLast({
+      Some: ({value}) => value,
+      None: () => 'nothing',
+    })(someString);
+
+    const noString: Option<string> = none();
+    const noStringRes = matchLast({
+      Some: ({value}) => value,
+      None: () => 'nothing',
+    })(noString);
+
+    expect(someStringRes).toEqual('str');
+    expect(noStringRes).toEqual('nothing');
+  });
+
+  test('matchLast works correctly for result', () => {
+    const okString: Result<string, string> = ok('ok string');
+    const okStringRes = matchLast({
+      Ok: ({value}) => value,
+      Error: ({value}) => value,
+    })(okString);
+
+    const errorString: Result<string, string> = error('error string');
+    const errorStringRes = matchLast({
+      Ok: ({value}) => value,
+      Error: ({value}) => value,
+    })(errorString);
 
     expect(okStringRes).toEqual('ok string');
     expect(errorStringRes).toEqual('error string');

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -83,7 +83,7 @@ describe('matchPI works correctly', () => {
       {
         Some: ({value}) => value,
       },
-      () => 'nothing',
+      (_option) => 'nothing',
     );
 
     const noString: Option<string> = none();
@@ -91,7 +91,7 @@ describe('matchPI works correctly', () => {
       {
         Some: ({value}) => value,
       },
-      () => 'nothing',
+      (_option) => 'nothing',
     );
 
     expect(someStringRes).toEqual('str');
@@ -104,7 +104,7 @@ describe('matchPI works correctly', () => {
       {
         Error: ({value}) => value,
       },
-      () => 'ok string',
+      (_result) => 'ok string',
     );
 
     const errorString: Result<string, string> = error('error string');
@@ -112,7 +112,7 @@ describe('matchPI works correctly', () => {
       {
         Error: ({value}) => value,
       },
-      () => 'ok string',
+      (_result) => 'ok string',
     );
 
     expect(okStringRes).toEqual('ok string');

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -2,7 +2,43 @@ import {result, option, adt, Option, Result} from '../src';
 
 const {some, none} = option;
 const {ok, error} = result;
-const {matchI} = adt;
+const {match, matchI} = adt;
+
+describe('match works correctly', () => {
+  test('match works correctly for option', () => {
+    const someString = some('str');
+    const someStringRes: string = match({
+      Some: ({value}) => value,
+      None: () => 'nothing',
+    })(someString);
+
+    const noString: Option<string> = none();
+    const noStringRes = match({
+      Some: (value) => value,
+      None: () => 'nothing',
+    })(noString);
+
+    expect(someStringRes).toEqual('str');
+    expect(noStringRes).toEqual('nothing');
+  });
+
+  test('match works correctly for result', () => {
+    const okString: Result<string, string> = ok('ok string');
+    const okStringRes = match({
+      Ok: ({value}) => value,
+      Error: ({value}) => value,
+    })(okString);
+
+    const errorString: Result<string, string> = error('error string');
+    const errorStringRes = match({
+      Ok: ({value}) => value,
+      Error: ({value}) => value,
+    })(errorString);
+
+    expect(okStringRes).toEqual('ok string');
+    expect(errorStringRes).toEqual('error string');
+  });
+});
 
 describe('matchI works correctly', () => {
   test('matchI works correctly for option', () => {

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -14,7 +14,7 @@ describe('match works correctly', () => {
 
     const noString: Option<string> = none();
     const noStringRes = match({
-      Some: (value) => value,
+      Some: ({value}) => value,
       None: () => 'nothing',
     })(noString);
 

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -2,18 +2,18 @@ import {result, option, adt, Option, Result} from '../src';
 
 const {some, none} = option;
 const {ok, error} = result;
-const {match, matchI, matchPI} = adt;
+const {match, matchLast, matchP} = adt;
 
-describe('match works correctly', () => {
-  test('match works correctly for option', () => {
+describe('matchLast works correctly', () => {
+  test('matchLast works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = match({
+    const someStringRes = matchLast({
       Some: ({value}) => value,
       None: () => 'nothing',
     })(someString);
 
     const noString: Option<string> = none();
-    const noStringRes = match({
+    const noStringRes = matchLast({
       Some: ({value}) => value,
       None: () => 'nothing',
     })(noString);
@@ -22,15 +22,15 @@ describe('match works correctly', () => {
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('match works correctly for result', () => {
+  test('matchLast works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = match({
+    const okStringRes = matchLast({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     })(okString);
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = match({
+    const errorStringRes = matchLast({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     })(errorString);
@@ -40,16 +40,16 @@ describe('match works correctly', () => {
   });
 });
 
-describe('matchI works correctly', () => {
-  test('matchI works correctly for option', () => {
+describe('match works correctly', () => {
+  test('match works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = matchI(someString)({
+    const someStringRes = match(someString)({
       Some: ({value}) => value,
       None: () => 'nothing',
     });
 
     const noString: Option<string> = none();
-    const noStringRes = matchI(noString)({
+    const noStringRes = match(noString)({
       Some: ({value}) => value,
       None: () => 'nothing',
     });
@@ -58,15 +58,15 @@ describe('matchI works correctly', () => {
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('matchI works correctly for result', () => {
+  test('match works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = matchI(okString)({
+    const okStringRes = match(okString)({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     });
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = matchI(errorString)({
+    const errorStringRes = match(errorString)({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     });
@@ -76,10 +76,10 @@ describe('matchI works correctly', () => {
   });
 });
 
-describe('matchPI works correctly', () => {
-  test('matchPI works correctly for option', () => {
+describe('matchP works correctly', () => {
+  test('matchP works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = matchPI(someString)(
+    const someStringRes = matchP(someString)(
       {
         Some: ({value}) => value,
       },
@@ -87,7 +87,7 @@ describe('matchPI works correctly', () => {
     );
 
     const noString: Option<string> = none();
-    const noStringRes = matchPI(noString)(
+    const noStringRes = matchP(noString)(
       {
         Some: ({value}) => value,
       },
@@ -98,9 +98,9 @@ describe('matchPI works correctly', () => {
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('matchPI works correctly for result', () => {
+  test('matchP works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = matchPI(okString)(
+    const okStringRes = matchP(okString)(
       {
         Error: ({value}) => value,
       },
@@ -108,7 +108,7 @@ describe('matchPI works correctly', () => {
     );
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = matchPI(errorString)(
+    const errorStringRes = matchP(errorString)(
       {
         Error: ({value}) => value,
       },

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -1,37 +1,37 @@
 import {some, none, Option} from '../src/option';
 import {ok, error, Result} from '../src/result';
-import {match} from '../src/adt';
+import {matchI} from '../src/adt';
 
-describe('match works correctly', () => {
-  test('match works correctly for option', () => {
+describe('matchI works correctly', () => {
+  test('matchI works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = match<Option<string>, string>({
+    const someStringRes = matchI(someString)({
       Some: ({value}) => value,
       None: () => 'nothing',
-    })(someString);
+    });
 
     const noString: Option<string> = none();
-    const noStringRes = match<Option<string>, string>({
+    const noStringRes = matchI(noString)({
       Some: ({value}) => value,
       None: () => 'nothing',
-    })(noString);
+    });
 
     expect(someStringRes).toEqual('str');
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('match works correctly for result', () => {
+  test('matchI works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = match<Result<string, string>, string>({
+    const okStringRes = matchI(okString)({
       Ok: ({value}) => value,
       Error: ({value}) => value,
-    })(okString);
+    });
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = match<Result<string, string>, string>({
+    const errorStringRes = matchI(errorString)({
       Ok: ({value}) => value,
       Error: ({value}) => value,
-    })(errorString);
+    });
 
     expect(okStringRes).toEqual('ok string');
     expect(errorStringRes).toEqual('error string');

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -2,7 +2,7 @@ import {result, option, adt, Option, Result} from '../src';
 
 const {some, none} = option;
 const {ok, error} = result;
-const {match, matchI} = adt;
+const {match, matchI, matchPI} = adt;
 
 describe('match works correctly', () => {
   test('match works correctly for option', () => {
@@ -70,6 +70,50 @@ describe('matchI works correctly', () => {
       Ok: ({value}) => value,
       Error: ({value}) => value,
     });
+
+    expect(okStringRes).toEqual('ok string');
+    expect(errorStringRes).toEqual('error string');
+  });
+});
+
+describe('matchPI works correctly', () => {
+  test('matchPI works correctly for option', () => {
+    const someString = some('str');
+    const someStringRes = matchPI(someString)(
+      {
+        Some: ({value}) => value,
+      },
+      () => 'nothing',
+    );
+
+    const noString: Option<string> = none();
+    const noStringRes = matchPI(noString)(
+      {
+        Some: ({value}) => value,
+      },
+      () => 'nothing',
+    );
+
+    expect(someStringRes).toEqual('str');
+    expect(noStringRes).toEqual('nothing');
+  });
+
+  test('matchPI works correctly for result', () => {
+    const okString: Result<string, string> = ok('ok string');
+    const okStringRes = matchPI(okString)(
+      {
+        Error: ({value}) => value,
+      },
+      () => 'ok string',
+    );
+
+    const errorString: Result<string, string> = error('error string');
+    const errorStringRes = matchPI(errorString)(
+      {
+        Error: ({value}) => value,
+      },
+      () => 'ok string',
+    );
 
     expect(okStringRes).toEqual('ok string');
     expect(errorStringRes).toEqual('error string');

--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -1,6 +1,8 @@
-import {some, none, Option} from '../src/option';
-import {ok, error, Result} from '../src/result';
-import {matchI} from '../src/adt';
+import {result, option, adt, Option, Result} from '../src';
+
+const {some, none} = option;
+const {ok, error} = result;
+const {matchI} = adt;
 
 describe('matchI works correctly', () => {
   test('matchI works correctly for option', () => {

--- a/packages/ts-utils/__test__/attempt.test.ts
+++ b/packages/ts-utils/__test__/attempt.test.ts
@@ -1,6 +1,7 @@
-import {attempt} from '../src/attempt';
-import {ok, error} from '../src/result';
-import {some} from '../src/option';
+import {attempt, result, option} from '../src';
+
+const {ok, error} = result;
+const {some} = option;
 
 describe('attempt works correctly', () => {
   test('it generates tags correctly', () => {

--- a/packages/ts-utils/__test__/index.test.ts
+++ b/packages/ts-utils/__test__/index.test.ts
@@ -1,4 +1,4 @@
-import * as utils from '../src/index';
+import * as utils from '../src';
 
 describe('All utils are exported', () => {
   test('adt utils are exported', () => {

--- a/packages/ts-utils/__test__/index.test.ts
+++ b/packages/ts-utils/__test__/index.test.ts
@@ -4,9 +4,9 @@ describe('All utils are exported', () => {
   test('adt utils are exported', () => {
     expect(utils).toHaveProperty('adt');
     expect(utils.adt).toHaveProperty('match');
-    expect(utils.adt).toHaveProperty('matchI');
+    expect(utils.adt).toHaveProperty('matchLast');
     expect(utils.adt).toHaveProperty('matchP');
-    expect(utils.adt).toHaveProperty('matchPI');
+    expect(utils.adt).toHaveProperty('matchPLast');
   });
   test('attempt utils are exported', () => {
     expect(utils).toHaveProperty('attempt');

--- a/packages/ts-utils/__test__/index.test.ts
+++ b/packages/ts-utils/__test__/index.test.ts
@@ -4,6 +4,9 @@ describe('All utils are exported', () => {
   test('adt utils are exported', () => {
     expect(utils).toHaveProperty('adt');
     expect(utils.adt).toHaveProperty('match');
+    expect(utils.adt).toHaveProperty('matchI');
+    expect(utils.adt).toHaveProperty('matchP');
+    expect(utils.adt).toHaveProperty('matchPI');
   });
   test('attempt utils are exported', () => {
     expect(utils).toHaveProperty('attempt');

--- a/packages/ts-utils/__test__/option.test.ts
+++ b/packages/ts-utils/__test__/option.test.ts
@@ -1,12 +1,6 @@
-import {
-  some,
-  isSome,
-  none,
-  isNone,
-  flatMap,
-  map,
-  getOrElse,
-} from '../src/option';
+import {option} from '../src';
+
+const {some, isSome, none, isNone, flatMap, map, getOrElse} = option;
 
 describe('some works correctly', () => {
   test('some generates tag correctly', () => {

--- a/packages/ts-utils/__test__/pipe.test.ts
+++ b/packages/ts-utils/__test__/pipe.test.ts
@@ -1,4 +1,4 @@
-import pipe from '../src/pipe';
+import {pipe} from '../src';
 
 function add1(x) {
   return x + 1;

--- a/packages/ts-utils/__test__/result.test.ts
+++ b/packages/ts-utils/__test__/result.test.ts
@@ -1,4 +1,6 @@
-import {
+import {option, result} from '../src';
+
+const {
   ok,
   error,
   isOk,
@@ -11,8 +13,8 @@ import {
   mapError,
   flatMap,
   flatMapError,
-} from '../src/result';
-import {some, none} from '../src/option';
+} = result;
+const {some, none} = option;
 
 describe('ok works correctly', () => {
   test('ok generates tag correctly', () => {

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -1,5 +1,5 @@
 // Adapted from: https://github.com/pfgray/ts-adt
-// but changing _type to _tag
+// - Mainly changing _type to _tag
 
 /**
  * A sum-type generator. Uses the keys of the passed type as string discriminators

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -172,28 +172,6 @@ function makeMatchPI<D extends string>(
 }
 
 /**
- * Generate match functions that switch on a specified discriminant field
- *
- * ```ts
- * import * as O from "fp-ts/Option";
- *
- * const [match, matchP, matchI, matchPI] = makeMatchers("_tag");
- *
- * pipe(
- *   O.fromNullable("value"),
- *   match({
- *     None: () => 0,
- *     Some: (v) => v.value,
- *   })
- * );
- * ```
- *
- * @param d the discriminant field to use
- */
-const makeMatchers = <D extends string>(d: D) =>
-  [makeMatch(d), makeMatchP(d), makeMatchI(d), makeMatchPI(d)] as const;
-
-/**
  * A sum-type generator. Uses the keys of the passed type as string discriminators
  *
  *
@@ -212,64 +190,65 @@ const makeMatchers = <D extends string>(d: D) =>
  */
 export type ADT<T extends Record<string, {}>> = MakeADT<'_tag', T>;
 
-export const [
-  /**
-   * Pattern matching for a sum type defined with ADT, with
-   * discriminant field "_tag"
-   *
-   * ```ts
-   * declare const foo: Option<string>
-   *
-   * pipe(
-   *   foo,
-   *   match({
-   *     none: () => 'none',
-   *     some: ({value}) => 'some'
-   *   })
-   * )
-   * ```
-   */
-  match,
-  /**
-   * Partial pattern matching for a sum type defined with ADT
-   *
-   * ```ts
-   * declare const foo: Option<string>
-   *
-   * pipe(
-   *   foo,
-   *   matchP({
-   *     some: ({value}) => 'some'
-   *   }, (_option) => 'none')
-   * )
-   * ```
-   */
-  matchP,
-  /**
-   * Inverted version of match, useful for better inference in some circumstances
-   *
-   * ```ts
-   * declare const foo: Option<string>
-   *
-   * matchI(foo)({
-   *   none: () => 'none',
-   *   some: ({value}) => 'some'
-   * })
-   * ```
-   */
-  matchI,
-  /**
-   * Inverted version of matchP, useful for better inference in some circumstances
-   *
-   * ```ts
-   * declare const foo: Option<string>
-   *
-   * matchPI(foo)({
-   *   some: ({value}) => 'some'
-   * }, (_option) => 'none')
-   * ```
-   */
-  matchPI,
-] = makeMatchers('_tag');
+/**
+ * Pattern matching for a sum type defined with ADT, with
+ * discriminant field "_tag"
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * pipe(
+ *   foo,
+ *   match({
+ *     none: () => 'none',
+ *     some: ({value}) => 'some'
+ *   })
+ * )
+ * ```
+ */
+export const match = makeMatch('_tag');
+
+/**
+ * Inverted version of match, useful for better inference in some circumstances
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * matchI(foo)({
+ *   none: () => 'none',
+ *   some: ({value}) => 'some'
+ * })
+ * ```
+ */
+export const matchI = makeMatchI('_tag');
+
+/**
+ * Partial pattern matching for a sum type defined with ADT
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * pipe(
+ *   foo,
+ *   matchP({
+ *     some: ({value}) => 'some'
+ *   }, (_option) => 'none')
+ * )
+ * ```
+ */
+export const matchP = makeMatchP('_tag');
+
+/**
+ * Inverted version of matchP, useful for better inference in some circumstances
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * matchPI(foo)({
+ *   some: ({value}) => 'some'
+ * }, (_option) => 'none')
+ * ```
+ */
+export const matchPI = makeMatchPI('_tag');
 
 export default {match, matchI, matchP, matchPI};

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -59,14 +59,14 @@ type MakeADTMember<D extends string, ADT, Type extends string> = Extract<
  *
  * pipe(
  *   foo,
- *   makeMatch("_tag")({
+ *   makeMatchLast("_tag")({
  *     none: () => 'none',
  *     some: ({value}) => 'some'
  *   })
  * )
  * ```
  */
-function makeMatch<D extends string>(
+function makeMatchLast<D extends string>(
   d: D,
 ): <ADT extends Record<D, string>, M extends MakeMatchObj<D, ADT, unknown>>(
   matchObj: M,
@@ -82,13 +82,13 @@ function makeMatch<D extends string>(
  *
  * pipe(
  *   foo,
- *   makeMatchP("_tag")({
+ *   makeMatchPLast("_tag")({
  *     some: ({value}) => 'some'
  *   }, (_option) => 'none')
  * )
  * ```
  */
-function makeMatchP<D extends string>(
+function makeMatchPLast<D extends string>(
   d: D,
 ): <
   ADT extends Record<D, string>,
@@ -125,13 +125,13 @@ type MakePartialReturns<
  * ```ts
  * declare const foo: Option<string>
  *
- * makeMatchI('_tag')(foo)({
+ * makeMatch('_tag')(foo)({
  *   none: () => 'none',
  *   some: ({value}) => 'some'
  * })
  * ```
  */
-function makeMatchI<D extends string>(
+function makeMatch<D extends string>(
   d: D,
 ): <ADT extends Record<D, string>>(
   v: ADT,
@@ -142,17 +142,17 @@ function makeMatchI<D extends string>(
 }
 
 /**
- * Inverted version of {@link makeMatchP}, useful for better inference in some circumstances
+ * Inverted version of {@link makeMatchPLast}, useful for better inference in some circumstances
  *
  * ```ts
  * declare const foo: Option<string>
  *
- * makeMatchPI("_tag")(foo)({
+ * makeMatchP("_tag")(foo)({
  *   some: ({value}) => 'some'
  * }, (_option) => 'none')
  * ```
  */
-function makeMatchPI<D extends string>(
+function makeMatchP<D extends string>(
   d: D,
 ): <ADT extends Record<D, string>>(
   v: ADT,
@@ -206,7 +206,7 @@ export type ADT<T extends Record<string, {}>> = MakeADT<'_tag', T>;
  * )
  * ```
  */
-export const match = makeMatch('_tag');
+export const matchLast = makeMatchLast('_tag');
 
 /**
  * Inverted version of match, useful for better inference in some circumstances
@@ -220,7 +220,7 @@ export const match = makeMatch('_tag');
  * })
  * ```
  */
-export const matchI = makeMatchI('_tag');
+export const match = makeMatch('_tag');
 
 /**
  * Partial pattern matching for a sum type defined with ADT
@@ -236,7 +236,7 @@ export const matchI = makeMatchI('_tag');
  * )
  * ```
  */
-export const matchP = makeMatchP('_tag');
+export const matchPLast = makeMatchPLast('_tag');
 
 /**
  * Inverted version of matchP, useful for better inference in some circumstances
@@ -249,6 +249,6 @@ export const matchP = makeMatchP('_tag');
  * }, (_option) => 'none')
  * ```
  */
-export const matchPI = makeMatchPI('_tag');
+export const matchP = makeMatchP('_tag');
 
-export default {match, matchI, matchP, matchPI};
+export default {match, matchLast, matchP, matchPLast};

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -18,4 +18,6 @@ export function match<T extends Match, R = unknown>(
   return (x) => pattern[x._tag](x);
 }
 
+// TODO: Update the ADT, by taking: https://github.com/pfgray/ts-adt/blob/master/src/ADT.ts as reference
+
 export default {match};

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -1,4 +1,4 @@
-// Inspired by: https://github.com/pfgray/ts-adt
+// Adapted from: https://github.com/pfgray/ts-adt
 // but changing _type to _tag
 
 /**

--- a/packages/ts-utils/src/index.ts
+++ b/packages/ts-utils/src/index.ts
@@ -1,9 +1,8 @@
-import option from './option';
-import result from './result';
-import pipe from './pipe';
-import attempt from './attempt';
-import adt from './adt';
-
+export {attempt} from './attempt';
+export * as adt from './adt';
+export * as option from './option';
+export {pipe} from './pipe';
+export * as result from './result';
 export type {ADT} from './adt';
-
-export {option, result, pipe, attempt, adt};
+export type {Option} from './option';
+export type {Result} from './result';

--- a/packages/ts-utils/src/index.ts
+++ b/packages/ts-utils/src/index.ts
@@ -4,4 +4,6 @@ import pipe from './pipe';
 import attempt from './attempt';
 import adt from './adt';
 
+export type {ADT} from './adt';
+
 export {option, result, pipe, attempt, adt};

--- a/packages/ts-utils/src/option.ts
+++ b/packages/ts-utils/src/option.ts
@@ -1,13 +1,6 @@
-interface None {
-  readonly _tag: 'None';
-}
+import {ADT} from './adt';
 
-interface Some<T> {
-  readonly _tag: 'Some';
-  readonly value: T;
-}
-
-export type Option<T> = Some<T> | None;
+export type Option<T> = ADT<{Some: {value: T}; None: {}}>;
 
 export function none<T>(): Option<T> {
   return {_tag: 'None'};

--- a/packages/ts-utils/src/result.ts
+++ b/packages/ts-utils/src/result.ts
@@ -1,16 +1,7 @@
-import option, {none, Option} from './option';
+import option, {Option} from './option';
+import {ADT} from './adt';
 
-interface Ok<T> {
-  readonly _tag: 'Ok';
-  readonly value: T;
-}
-
-interface Error<T> {
-  readonly _tag: 'Error';
-  readonly value: T;
-}
-
-export type Result<T, U> = Ok<T> | Error<U>;
+export type Result<T, U> = ADT<{Ok: {value: T}; Error: {value: U}}>;
 
 export function ok<T, U>(value: T): Result<T, U> {
   return {_tag: 'Ok', value};


### PR DESCRIPTION
[ts-utils] Update the matching implementation by taking [ts-adt](https://github.com/pfgray/ts-adt) into consideration. Reason:

1. It will be nice to be able to use wildcards (`_`) in the pattern matching
2. It will be nice to be able to use some function to create an ADT type (i.e. we currently need to declare the type interface manually) 