### PR TITLE
[ts-utils] adt - mark unsafe operations

### DIFF
--- a/packages/ts-utils/__test__/adt.test.ts
+++ b/packages/ts-utils/__test__/adt.test.ts
@@ -2,7 +2,7 @@ import {result, option, adt, Option, Result} from '../src';
 
 const {some, none} = option;
 const {ok, error} = result;
-const {match, matchLast, matchP, matchPLast} = adt;
+const {match, unsafeMatchLast, matchP, unsafeMatchPLast} = adt;
 
 describe('match works correctly', () => {
   test('match works correctly for option', () => {
@@ -40,16 +40,16 @@ describe('match works correctly', () => {
   });
 });
 
-describe('matchLast works correctly', () => {
-  test('matchLast works correctly for option', () => {
+describe('unsafeMatchLast works correctly', () => {
+  test('unsafeMatchLast works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = matchLast({
+    const someStringRes = unsafeMatchLast({
       Some: ({value}) => value,
       None: () => 'nothing',
     })(someString);
 
     const noString: Option<string> = none();
-    const noStringRes = matchLast({
+    const noStringRes = unsafeMatchLast({
       Some: ({value}) => value,
       None: () => 'nothing',
     })(noString);
@@ -58,15 +58,15 @@ describe('matchLast works correctly', () => {
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('matchLast works correctly for result', () => {
+  test('unsafeMatchLast works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = matchLast({
+    const okStringRes = unsafeMatchLast({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     })(okString);
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = matchLast({
+    const errorStringRes = unsafeMatchLast({
       Ok: ({value}) => value,
       Error: ({value}) => value,
     })(errorString);
@@ -120,10 +120,10 @@ describe('matchP works correctly', () => {
   });
 });
 
-describe('matchPLast works correctly', () => {
-  test('matchPLast works correctly for option', () => {
+describe('unsafeMatchPLast works correctly', () => {
+  test('unsafeMatchPLast works correctly for option', () => {
     const someString = some('str');
-    const someStringRes = matchPLast(
+    const someStringRes = unsafeMatchPLast(
       {
         Some: ({value}) => value,
       },
@@ -131,7 +131,7 @@ describe('matchPLast works correctly', () => {
     )(someString);
 
     const noString: Option<string> = none();
-    const noStringRes = matchPLast(
+    const noStringRes = unsafeMatchPLast(
       {
         Some: ({value}) => value,
       },
@@ -142,9 +142,9 @@ describe('matchPLast works correctly', () => {
     expect(noStringRes).toEqual('nothing');
   });
 
-  test('matchPLast works correctly for result', () => {
+  test('unsafeMatchPLast works correctly for result', () => {
     const okString: Result<string, string> = ok('ok string');
-    const okStringRes = matchPLast(
+    const okStringRes = unsafeMatchPLast(
       {
         Error: ({value}) => value,
       },
@@ -152,7 +152,7 @@ describe('matchPLast works correctly', () => {
     )(okString);
 
     const errorString: Result<string, string> = error('error string');
-    const errorStringRes = matchPLast(
+    const errorStringRes = unsafeMatchPLast(
       {
         Error: ({value}) => value,
       },

--- a/packages/ts-utils/__test__/index.test.ts
+++ b/packages/ts-utils/__test__/index.test.ts
@@ -4,9 +4,9 @@ describe('All utils are exported', () => {
   test('adt utils are exported', () => {
     expect(utils).toHaveProperty('adt');
     expect(utils.adt).toHaveProperty('match');
-    expect(utils.adt).toHaveProperty('matchLast');
+    expect(utils.adt).toHaveProperty('unsafeMatchLast');
     expect(utils.adt).toHaveProperty('matchP');
-    expect(utils.adt).toHaveProperty('matchPLast');
+    expect(utils.adt).toHaveProperty('unsafeMatchPLast');
   });
   test('attempt utils are exported', () => {
     expect(utils).toHaveProperty('attempt');

--- a/packages/ts-utils/src/adt.ts
+++ b/packages/ts-utils/src/adt.ts
@@ -59,14 +59,14 @@ type MakeADTMember<D extends string, ADT, Type extends string> = Extract<
  *
  * pipe(
  *   foo,
- *   makeMatchLast("_tag")({
+ *   makeUnsafeMatchLast("_tag")({
  *     none: () => 'none',
  *     some: ({value}) => 'some'
  *   })
  * )
  * ```
  */
-function makeMatchLast<D extends string>(
+function makeUnsafeMatchLast<D extends string>(
   d: D,
 ): <ADT extends Record<D, string>, M extends MakeMatchObj<D, ADT, unknown>>(
   matchObj: M,
@@ -82,13 +82,13 @@ function makeMatchLast<D extends string>(
  *
  * pipe(
  *   foo,
- *   makeMatchPLast("_tag")({
+ *   makeUnsafeMatchPLast("_tag")({
  *     some: ({value}) => 'some'
  *   }, (_option) => 'none')
  * )
  * ```
  */
-function makeMatchPLast<D extends string>(
+function makeUnsafeMatchPLast<D extends string>(
   d: D,
 ): <
   ADT extends Record<D, string>,
@@ -142,7 +142,7 @@ function makeMatch<D extends string>(
 }
 
 /**
- * Inverted version of {@link makeMatchPLast}, useful for better inference in some circumstances
+ * Inverted version of {@link makeUnsafeMatchPLast}, useful for better inference in some circumstances
  *
  * ```ts
  * declare const foo: Option<string>
@@ -206,7 +206,7 @@ export type ADT<T extends Record<string, {}>> = MakeADT<'_tag', T>;
  * )
  * ```
  */
-export const matchLast = makeMatchLast('_tag');
+export const unsafeMatchLast = makeUnsafeMatchLast('_tag');
 
 /**
  * Inverted version of match, useful for better inference in some circumstances
@@ -236,7 +236,7 @@ export const match = makeMatch('_tag');
  * )
  * ```
  */
-export const matchPLast = makeMatchPLast('_tag');
+export const unsafeMatchPLast = makeUnsafeMatchPLast('_tag');
 
 /**
  * Inverted version of matchP, useful for better inference in some circumstances
@@ -251,4 +251,4 @@ export const matchPLast = makeMatchPLast('_tag');
  */
 export const matchP = makeMatchP('_tag');
 
-export default {match, matchLast, matchP, matchPLast};
+export default {match, unsafeMatchLast, matchP, unsafeMatchPLast};


### PR DESCRIPTION
Mark unsafe utils in ADT with `unsafe` prefix.